### PR TITLE
Fix pkg-config file library and path flags

### DIFF
--- a/libmessaging-menu/messaging-menu.pc.in
+++ b/libmessaging-menu/messaging-menu.pc.in
@@ -1,11 +1,11 @@
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libdir=@libdir@
-includedir=@includedir@/ayatana-messaging-menu
+includedir=@includedir@/messaging-menu
 
 Name: Ayatana Messaging Menu Library
 Description: Ayatana Messaging Menu client library
 Version: @VERSION@
 Requires: gio-unix-2.0
-Libs: -L${libdir} -layatana-messaging-menu
+Libs: -L${libdir} -lmessaging-menu
 Cflags: -I${includedir}


### PR DESCRIPTION
The ayatana prefix was dropped from the library name and the include
directory, but the pkg-config file was not updated. Fix it.

Fixes Debian bug #923958