### PR TITLE
Start indicator in systemd when ayatana-indicators.target is started.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,19 @@ AC_ARG_WITH([indicator-dir],
 	    [with_indicator_dir=$datadir/ayatana/indicators])
 AC_SUBST([INDICATOR_DIR], [$with_indicator_dir])
 
+#########################
+# Check for systemd
+#########################
+PKG_CHECK_MODULES(SYSTEMD,  systemd,
+    [has_systemd=yes],
+    []
+)
+if test "x$has_systemd" = "xyes"; then
+	SYSTEMD_USERDIR=`$PKG_CONFIG --variable=systemduserunitdir systemd`
+	AC_SUBST(SYSTEMD_USERDIR)
+	AC_DEFINE(HAVE_SYSTEMD, 1, [create ayatana-indicator-application.service for systemd])
+fi
+
 ###########################
 # gcov coverage reporting
 ###########################

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,3 +1,5 @@
+NULL =
+
 SUBDIRS = icons
 
 xdg_autostartdir = /etc/xdg/autostart
@@ -9,12 +11,25 @@ xdg_autostart_DATA = ayatana-indicator-messages.desktop
 gsettings_SCHEMAS = org.ayatana.indicator.messages.gschema.xml
 @GSETTINGS_RULES@
 
+#if defined(HAVE_SYSTEMD)
+systemdservice_file = ayatana-indicator-messages.service
+$(systemdservice_file): $(systemdservice_file).in
+	$(AM_V_GEN) sed -e "s|\@pkglibexecdir\@|$(pkglibexecdir)|" $< > $@
+
+systemddir = $(SYSTEMD_USERDIR)
+systemd_DATA = $(systemdservice_file)
+#endif
+
 indicatordir = $(INDICATOR_DIR)
 dist_indicator_DATA = org.ayatana.indicator.messages
 
 EXTRA_DIST = \
 	ayatana-indicator-messages.desktop.in \
-	$(gsettings_SCHEMAS)
+	$(gsettings_SCHEMAS) \
+	$(systemdservice_file).in \
+	$(NULL)
 
 CLEANFILES = \
 	$(xdg_autostart_DATA) \
+	$(systemdservice_file) \
+	$(NULL)

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,12 +6,6 @@ xdg_autostart_DATA = ayatana-indicator-messages.desktop
 %.desktop: %.desktop.in
 	$(AM_V_GEN) sed -e "s|\@pkglibexecdir\@|$(pkglibexecdir)|" $< > $@
 
-upstart_jobsdir = $(datadir)/upstart/sessions/
-upstart_jobs_DATA = ayatana-indicator-messages.conf
-
-%.conf: %.conf.in
-	$(AM_V_GEN) sed -e "s|\@pkglibexecdir\@|$(pkglibexecdir)|" $< > $@
-
 gsettings_SCHEMAS = org.ayatana.indicator.messages.gschema.xml
 @GSETTINGS_RULES@
 
@@ -20,9 +14,7 @@ dist_indicator_DATA = org.ayatana.indicator.messages
 
 EXTRA_DIST = \
 	ayatana-indicator-messages.desktop.in \
-	ayatana-indicator-messages.conf.in \
 	$(gsettings_SCHEMAS)
 
 CLEANFILES = \
 	$(xdg_autostart_DATA) \
-	$(upstart_jobs_DATA)

--- a/data/ayatana-indicator-messages.conf.in
+++ b/data/ayatana-indicator-messages.conf.in
@@ -1,9 +1,0 @@
-description "Ayatana Indicator Messages Service"
-
-start on ayatana-indicator-services-start
-stop on desktop-end or ayatana-indicator-services-end
-
-respawn
-respawn limit 2 10
-
-exec $SNAP@pkglibexecdir@/ayatana-indicator-messages-service

--- a/data/ayatana-indicator-messages.service.in
+++ b/data/ayatana-indicator-messages.service.in
@@ -1,0 +1,11 @@
+[Unit]
+Description=Ayatana Indicator Messages Service
+PartOf=graphical-session.target
+PartOf=ayatana-indicators.target
+
+[Service]
+ExecStart=@pkglibexecdir@/ayatana-indicator-messages-service
+Restart=on-failure
+
+[Install]
+WantedBy=ayatana-indicators.target

--- a/debian/ayatana-indicator-messages.install
+++ b/debian/ayatana-indicator-messages.install
@@ -1,6 +1,5 @@
 usr/lib/*/ayatana-indicator-messages/ayatana-indicator-messages-service
 usr/share/ayatana/indicators
-usr/share/upstart
 usr/share/glib-2.0
 usr/share/icons
 usr/share/locale

--- a/debian/ayatana-indicator-messages.install
+++ b/debian/ayatana-indicator-messages.install
@@ -1,4 +1,5 @@
 usr/lib/*/ayatana-indicator-messages/ayatana-indicator-messages-service
+usr/lib/systemd
 usr/share/ayatana/indicators
 usr/share/glib-2.0
 usr/share/icons

--- a/debian/ayatana-indicator-messages.links
+++ b/debian/ayatana-indicator-messages.links
@@ -1,0 +1,3 @@
+# Because dh-systemd does not support user units for compat levels below 12, we manually make the WantedBy link
+# FIXME: drop this once we bump DH compat level to 12 or higher
+/usr/lib/systemd/user/ayatana-indicator-messages.service /usr/lib/systemd/user/ayatana-indicators.target.wants/ayatana-indicator-messages.service

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Mike Gabriel <mike.gabriel@das-netzwerkteam.de>
 Build-Depends: debhelper (>= 9),
                dh-autoreconf | debhelper (>= 9.20160403~),
+               dh-systemd | debhelper (>= 10.2~),
                gobject-introspection (>= 0.9.12-4~),
                gtk-doc-tools,
                intltool,
@@ -14,6 +15,7 @@ Build-Depends: debhelper (>= 9),
                mate-common,
                python3-dbusmock,
                valac,
+               systemd [linux-any],
 Standards-Version: 4.2.1
 Homepage: https://github.com/AyatanaIndicators/ayatana-indicator-messages
 Vcs-Git: https://github.com/AyatanaIndicators/ayatana-indicator-messages

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ DPKG_EXPORT_BUILDFLAGS = 1
 include /usr/share/dpkg/buildflags.mk
 
 %:
-	dh $@ --with autoreconf,gir
+	dh $@ --with autoreconf,gir,systemd
 
 override_dh_autoreconf:
 	if [ ! -e po/ayatana-indicator-messages.pot.bak ]; then \


### PR DESCRIPTION
This PR provides the system service file (no .service file so far).

Please merge #9 first, before merging this (to avoid patch conflicts).