### PR TITLE
Allow autostart for Budgie Desktop

### DIFF
--- a/data/ayatana-indicator-messages.desktop.in
+++ b/data/ayatana-indicator-messages.desktop.in
@@ -5,4 +5,4 @@ Exec=@pkglibexecdir@/ayatana-indicator-messages-service
 NoDisplay=true
 StartupNotify=false
 Terminal=false
-OnlyShowIn=Unity;MATE;XFCE;
+OnlyShowIn=Unity;MATE;XFCE;Budgie


### PR DESCRIPTION
Hi,

for the next release of our budgie-indicator-applet to Debian I will be enabling the support of this ayatana indicator. This is because users have requested the abilities of this indicator for the budgie-desktop.

Please can you review and accept this PR to ensure the service is autostarted for budgie users.

thx