### PR TITLE
account-service: Do not unref UserManager owned user

### DIFF
--- a/src/im-accounts-service.c
+++ b/src/im-accounts-service.c
@@ -149,7 +149,6 @@ on_user_manager_loaded (ActUserManager * manager, GParamSpec * pspect, gpointer 
     user = act_user_manager_get_user(priv->user_manager, g_get_user_name());
     if (user != NULL) {
         user_changed(priv->user_manager, user, user_data);
-        g_object_unref(user);
     }
 }
 


### PR DESCRIPTION
`act_user_manager_get_user()` is a transfer-none function as users are cached internally and the ownership is not passed around, so we should not unref the user, or it will be destroyed during loading.

Fixes: https://gitlab.freedesktop.org/accountsservice/accountsservice/-/issues/114