### PR TITLE
tests/CMakeLists.txt: Drop hardcoded -no-pie linker flags

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,6 @@ add_dependencies("indicator-messages-service" "ayatana-indicator-messages-servic
 # test-gactionmuxer
 
 add_executable("test-gactionmuxer" test-gactionmuxer.cpp)
-target_link_options("test-gactionmuxer" PRIVATE -no-pie)
 target_include_directories("test-gactionmuxer" PUBLIC ${PROJECT_DEPS_INCLUDE_DIRS} "${CMAKE_SOURCE_DIR}/src")
 target_link_libraries("test-gactionmuxer" "indicator-messages-service" ${PROJECT_DEPS_LIBRARIES} ${GTEST_LIBRARIES} ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIBRARIES})
 add_test("test-gactionmuxer" "test-gactionmuxer")
@@ -59,7 +58,6 @@ add_custom_target("gschemas-compiled" ALL DEPENDS gschemas.compiled)
 
 pkg_check_modules(DBUSTEST REQUIRED dbustest-1)
 add_executable("indicator-test" indicator-test.cpp)
-target_link_options("indicator-test" PRIVATE -no-pie)
 target_include_directories("indicator-test" PUBLIC ${PROJECT_DEPS_INCLUDE_DIRS} ${DBUSTEST_INCLUDE_DIRS} "${CMAKE_SOURCE_DIR}/libmessaging-menu")
 target_link_libraries("indicator-test" "messaging-menu" ${PROJECT_DEPS_LIBRARIES} ${DBUSTEST_LIBRARIES} ${GTEST_LIBRARIES} ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIBRARIES})
 target_compile_definitions(


### PR DESCRIPTION
These cause the build to fail when… the compiler expects PIE usage: https://github.com/NixOS/nixpkgs/pull/372768

```
[ 99%] Linking CXX executable test-gactionmuxer
/nix/store/j7p46r8v9gcpbxx89pbqlh61zhd33gzv-binutils-2.43.1/bin/ld: /nix/store/l89iqc7am6i60y8vk507zwrzxf0wcd3v-gcc-14-20241116/lib/gcc/x86_64-unknown-linux-gnu/14.2.1/crtbegin.o: relocation R_X86_64_32 against hidden symbol `__TMC_END__' can not be used when making a PIE object
/nix/store/j7p46r8v9gcpbxx89pbqlh61zhd33gzv-binutils-2.43.1/bin/ld: failed to set dynamic section sizes: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [tests/CMakeFiles/test-gactionmuxer.dir/build.make:102: tests/test-gactionmuxer] Error 1
```

Is there a reason for these being there? They were introduced 4y ago, together with all of the CMake code. Building with & without PIE & running the resulting binaries seems to work fine once these are removed, at least in Nixpkgs.